### PR TITLE
chore: turn on github action annotation output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
           python-version: "3.10"
       - name: Install Custodian
         run: |
-          pip install c7n_left c7n
+          pip install 'c7n_left @ git+https://github.com/kapilt/cloud-custodian@86c45aa#subdirectory=tools/c7n_left'
+          pip install c7n
       - name: Pull Modules
         run: |
           terraform -chdir=root-module get
       - name: Check Terraform
         run: |
-          c7n-left run --policy-dir policies -d root-module
+          c7n-left run --policy-dir policies -d root-module -o github

--- a/root-module/main.tf
+++ b/root-module/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 resource "aws_sqs_queue" "test_sqs" {
   name = uuid()
   sqs_managed_sse_enabled = true
-#  tags = {
-#    Environment = "Dev"
-#  }
+  tags = {
+    Environment = "Dev"
+  }
 }

--- a/root-module/main.tf
+++ b/root-module/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 resource "aws_sqs_queue" "test_sqs" {
   name = uuid()
   sqs_managed_sse_enabled = true
-  tags = {
-    Environment = "Dev"
-  }
+#  tags = {
+#    Environment = "Dev"
+#  }
 }


### PR DESCRIPTION
updates version of c7n-left to one that includes standard cli output when doing annotation output.